### PR TITLE
Wrap default (implicit) marshaller in an object to avoid conflicts

### DIFF
--- a/http-testkit-client/src/test/scala/com/wix/e2e/http/client/HttpClientTransformersTest.scala
+++ b/http-testkit-client/src/test/scala/com/wix/e2e/http/client/HttpClientTransformersTest.scala
@@ -4,7 +4,7 @@ import java.net.URLEncoder
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.HttpCookiePair
-import com.wix.e2e.http.api.Marshaller
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.client.transformers.HttpClientTransformers
 import com.wix.e2e.http.exceptions.UserAgentModificationNotSupportedException
 import com.wix.e2e.http.matchers.RequestMatchers._
@@ -128,7 +128,7 @@ class HttpClientTransformersTest extends Spec with HttpClientTransformers {
 
   "ResponseTransformers" should {
     "easily extract content from response" in new ctx {
-      HttpResponse(entity = Marshaller.marshaller.marshall(payload)).extractAs[SomePayload] must_=== payload
+      HttpResponse(entity = marshaller.marshall(payload)).extractAs[SomePayload] must_=== payload
     }
   }
 }

--- a/http-testkit-contract-tests-custom-marshaller/src/test/scala/com/wix/e2e/http/marshaller/HttpClientCustomMarshallerContractTest.scala
+++ b/http-testkit-contract-tests-custom-marshaller/src/test/scala/com/wix/e2e/http/marshaller/HttpClientCustomMarshallerContractTest.scala
@@ -1,5 +1,6 @@
 package com.wix.e2e.http.marshaller
 
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.client.transformers.HttpClientTransformers
 import com.wix.e2e.http.drivers.MarshallerTestSupport
 import com.wix.e2e.http.drivers.MarshallingTestObjects.SomeCaseClass

--- a/http-testkit-contract-tests-no-custom-marshaller/src/test/scala/com/wix/e2e/http/marshaller/HttpClientNoCustomMarshallerContractTest.scala
+++ b/http-testkit-contract-tests-no-custom-marshaller/src/test/scala/com/wix/e2e/http/marshaller/HttpClientNoCustomMarshallerContractTest.scala
@@ -1,5 +1,6 @@
 package com.wix.e2e.http.marshaller
 
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.client.transformers.HttpClientTransformers
 import com.wix.e2e.http.drivers.MarshallerMatchers._
 import com.wix.e2e.http.drivers.MarshallerTestSupport

--- a/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/BlockingHttpClientContractTest.scala
+++ b/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/BlockingHttpClientContractTest.scala
@@ -1,6 +1,7 @@
 package com.wix.e2e.http.client
 
 import akka.http.scaladsl.model.HttpResponse
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.client.sync._
 import com.wix.e2e.http.drivers.{HttpClientTestSupport, StubWebServerProvider}
 import com.wix.e2e.http.matchers.RequestMatchers._

--- a/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/NonBlockingHttpClientContractTest.scala
+++ b/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/NonBlockingHttpClientContractTest.scala
@@ -1,6 +1,7 @@
 package com.wix.e2e.http.client
 
 import akka.http.scaladsl.model.HttpResponse
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.drivers.{HttpClientTestSupport, StubWebServerProvider}
 import com.wix.e2e.http.matchers.RequestMatchers._
 import com.wix.e2e.http.matchers.ResponseMatchers.beConnectionRefused

--- a/http-testkit-core/src/main/scala/com/wix/e2e/http/api/Marshaller.scala
+++ b/http-testkit-core/src/main/scala/com/wix/e2e/http/api/Marshaller.scala
@@ -12,8 +12,9 @@ trait Marshaller {
 
 
 object Marshaller {
-
-  implicit val marshaller: Marshaller = defaultMarshaller
+  object Implicits {
+    implicit val marshaller: Marshaller = defaultMarshaller
+  }
 
   private def defaultMarshaller =
     DefaultMarshaller.lookup

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/RequestBodyMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/RequestBodyMatchersTest.scala
@@ -1,6 +1,5 @@
 package com.wix.e2e.http.matchers.internal
 
-import com.wix.e2e.http.api.Marshaller
 import com.wix.e2e.http.matchers.RequestMatchers._
 import com.wix.e2e.http.matchers.drivers.HttpRequestFactory._
 import com.wix.e2e.http.matchers.drivers.MarshallingTestObjects.SomeCaseClass
@@ -12,9 +11,7 @@ import org.specs2.specification.Scope
 
 class RequestBodyMatchersTest extends Spec with MatchersTestSupport {
 
-  trait ctxNoMarshaller extends Scope with HttpResponseTestSupport with MarshallerTestSupport
-  trait ctx extends ctxNoMarshaller with CustomMarshallerProvider
-
+  trait ctx extends Scope with HttpResponseTestSupport with MarshallerTestSupport with CustomMarshallerProvider
 
   "ResponseBodyMatchers" should {
 
@@ -67,10 +64,6 @@ class RequestBodyMatchersTest extends Spec with MatchersTestSupport {
 
       aRequestWith(content) must haveBodyEntityThat(must = be_===(someObject))
       aRequestWith(content) must not( haveBodyEntityThat(must = be_===(anotherObject)) )
-    }
-
-    "provide a default json marshaller in case no marshaller is specified" in new ctxNoMarshaller {
-      aRequestWith(Marshaller.marshaller.marshall(someObject)) must haveBodyWith(someObject)
     }
   }
 }

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyAndStatusMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyAndStatusMatchersTest.scala
@@ -2,6 +2,7 @@ package com.wix.e2e.http.matchers.internal
 
 import com.wix.e2e.http.api.Marshaller
 import com.wix.e2e.http.matchers.ResponseMatchers._
+import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.matchers.drivers.HttpResponseFactory._
 import com.wix.e2e.http.matchers.drivers.HttpResponseMatchers._
 import com.wix.e2e.http.matchers.drivers.HttpResponseTestSupport
@@ -47,19 +48,18 @@ class ResponseBodyAndStatusMatchersTest extends Spec {
     }
 
     "match successful request with entity" in new ctx {
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
     }
 
     "match successful request with entity with custom marshaller" in new ctx {
-      implicit val marshaller = Marshaller.marshaller
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
     }
 
     "match successful request with entity matcher" in new ctx {
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must beSuccessfulWithEntityThat( must = be_===( someObject ) )
-      aSuccessfulResponseWith(Marshaller.marshaller.marshall(someObject)) must not( beSuccessfulWithEntityThat( must = be_===( anotherObject ) ) )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWithEntityThat( must = be_===( someObject ) )
+      aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWithEntityThat( must = be_===( anotherObject ) ) )
     }
 
     "match successful request with headers" in new ctx {

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyMatchersTest.scala
@@ -1,6 +1,5 @@
 package com.wix.e2e.http.matchers.internal
 
-import com.wix.e2e.http.api.Marshaller
 import com.wix.e2e.http.matchers.ResponseMatchers._
 import com.wix.e2e.http.matchers.drivers.HttpResponseFactory._
 import com.wix.e2e.http.matchers.drivers.MarshallingTestObjects.SomeCaseClass
@@ -11,9 +10,7 @@ import org.specs2.specification.Scope
 
 class ResponseBodyMatchersTest extends Spec with MatchersTestSupport {
 
-  trait ctxNoMarshaller extends Scope with HttpResponseTestSupport with MarshallerTestSupport
-  trait ctx extends ctxNoMarshaller with CustomMarshallerProvider
-
+  trait ctx extends Scope with HttpResponseTestSupport with MarshallerTestSupport with CustomMarshallerProvider
 
   "ResponseBodyMatchers" should {
 
@@ -66,10 +63,6 @@ class ResponseBodyMatchersTest extends Spec with MatchersTestSupport {
 
       aResponseWith(content) must haveBodyThat(must = be_===(someObject))
       aResponseWith(content) must not( haveBodyThat(must = be_===(anotherObject)) )
-    }
-
-    "provide a default json marshaller in case no marshaller is specified" in new ctxNoMarshaller {
-      aResponseWith(Marshaller.marshaller.marshall(someObject)) must haveBodyWith(someObject)
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.4"
+version in ThisBuild := "0.1.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.4-SNAPSHOT"
+version in ThisBuild := "0.1.4"


### PR DESCRIPTION
@liucijus This helps with your problem. Essentially, wrong (implicit) marshaller was being picked by the compiler. 