### PR TITLE
Pre-consume response in the client

### DIFF
--- a/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/BlockingHttpClientContractTest.scala
+++ b/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/BlockingHttpClientContractTest.scala
@@ -1,6 +1,6 @@
 package com.wix.e2e.http.client
 
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
 import com.wix.e2e.http.api.Marshaller.Implicits._
 import com.wix.e2e.http.client.sync._
 import com.wix.e2e.http.drivers.{HttpClientTestSupport, StubWebServerProvider}
@@ -149,6 +149,11 @@ class BlockingHttpClientContractTest extends Spec {
 
     "match connection failed" in new ctx {
       get(path)(ClosedPort) must beConnectionRefused
+    }
+
+    "returns response with pre-consumed entity (frees up connection)" in new ctx {
+      val response = get("/big-response/512_KiB")
+      response.entity must beAnInstanceOf[HttpEntity.Strict]
     }
   }
 }

--- a/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/NonBlockingHttpClientContractTest.scala
+++ b/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/client/NonBlockingHttpClientContractTest.scala
@@ -1,7 +1,8 @@
 package com.wix.e2e.http.client
 
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
 import com.wix.e2e.http.api.Marshaller.Implicits._
+import com.wix.e2e.http.client.sync.get
 import com.wix.e2e.http.drivers.{HttpClientTestSupport, StubWebServerProvider}
 import com.wix.e2e.http.matchers.RequestMatchers._
 import com.wix.e2e.http.matchers.ResponseMatchers.beConnectionRefused
@@ -150,6 +151,11 @@ class NonBlockingHttpClientContractTest extends Spec with NonBlockingHttpClientS
 
     "match connection failed" in new ctx {
       get("/nowhere")(ClosedPort) must beConnectionRefused.await
+    }
+
+    "returns response with pre-consumed entity (frees up connection)" in new ctx {
+      val response = waitFor(get("/big-response/512_KiB"))
+      response.entity must beAnInstanceOf[HttpEntity.Strict]
     }
   }
 }

--- a/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/drivers/StubWebServerProvider.scala
+++ b/http-testkit-contract-tests/src/test/scala/com/wix/e2e/http/drivers/StubWebServerProvider.scala
@@ -1,5 +1,6 @@
 package com.wix.e2e.http.drivers
 
+import akka.http.scaladsl.model._
 import com.wix.e2e.http.BaseUri
 import com.wix.e2e.http.server.WebServerFactory.aStubWebServer
 import org.specs2.mutable.After
@@ -7,6 +8,11 @@ import org.specs2.mutable.After
 trait StubWebServerProvider extends After {
   val server = aStubWebServer.build
                              .start()
+
+  server.appendAll({
+    case HttpRequest(HttpMethods.GET, uri, _, _, _) if uri.path.toString() == "//big-response/512_KiB" =>
+      HttpResponse(entity = HttpEntity("." * 1024 * 512))
+  })
 
   def after = server.stop()
 


### PR DESCRIPTION
This is what I propose as a fix for https://github.com/wix/wix-http-testkit/issues/31 .

I don't think steams have any use in test environment. It does slow tests down a little, though.

CC @noam-almog @liucijus 