### PR TITLE
Bring back auto-consume response behaviour

### DIFF
--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/drivers/HttpResponseTestSupport.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/drivers/HttpResponseTestSupport.scala
@@ -109,10 +109,13 @@ object HttpResponseFactory {
     aResponseWithoutBody.copy(entity = r.entity.withContentType(ContentType.parse(contentType).right.get))
   }
 
-  def aChunkedResponse = HttpResponse(entity = HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source.single(randomStr)) )
+  def aChunkedResponse = 
+    HttpResponse(entity = HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source.single(randomStr)),
+                 headers = immutable.Seq(`Transfer-Encoding`(TransferEncodings.chunked)))
+  
   def aChunkedResponseWith(transferEncoding: TransferEncoding) =
     HttpResponse(entity = HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source.single(randomStr)),
-                 headers = immutable.Seq(`Transfer-Encoding`(transferEncoding)) )
+                 headers = immutable.Seq(`Transfer-Encoding`(transferEncoding, TransferEncodings.chunked)) )
 
   def aResponseWithoutTransferEncoding = HttpResponse()
   def aResponseWithTransferEncodings(transferEncoding: TransferEncoding, tail: TransferEncoding*) =


### PR DESCRIPTION
This brings back the behaviour of the testkit where the response entities are automatically consumes and can be consumed multiple times afterwards. To make the chunked encoding detection work, we check if the response entity is chunked and add the encoding to the headers in the response. We only consume the entity fully when using the blocking client