### PR TITLE
Fixed typo in Response matchers

### DIFF
--- a/http-testkit-specs2/src/main/scala/com/wix/e2e/http/matchers/internal/matchers.scala
+++ b/http-testkit-specs2/src/main/scala/com/wix/e2e/http/matchers/internal/matchers.scala
@@ -91,7 +91,7 @@ trait ResponseHeadersMatchers {
 
   def haveTheSameHeadersAs(headers: (String, String)*): ResponseMatcher =
     haveHeaderInternal( headers, r => r.extra.isEmpty && r.missing.isEmpty,
-                        res => s"Request header is not identical, missing headers from request: [${res.missing.map(_._1).mkString(", ")}], request contained extra headers: [${res.extra.map(_._1).mkString(", ")}]." )
+                        res => s"Response header is not identical, missing headers from response: [${res.missing.map(_._1).mkString(", ")}], response contained extra headers: [${res.extra.map(_._1).mkString(", ")}]." )
 
   private def haveHeaderInternal(headers: Seq[(String, String)], comparator: HeaderComparisonResult => Boolean, errorMessage: HeaderComparisonResult => String): ResponseMatcher = new ResponseMatcher {
 
@@ -260,7 +260,7 @@ trait ResponseContentTypeMatchers {
       val expected = ContentType.parse(contentType)
 
       (actual, expected) match {
-        case (a, _) if a == NoContentType => failure("Request body does not have a set content type", t)
+        case (a, _) if a == NoContentType => failure("Response body does not have a set content type", t)
         case (_, Left(_)) => failure(s"Cannot match against a malformed content type: $contentType", t)
         case (a, Right(e)) if a == e => success("ok", t)
         case (a, Right(e)) if a != e => failure(s"Expected content type [$e] does not match actual content type [$a]", t)

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyAndStatusMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseBodyAndStatusMatchersTest.scala
@@ -16,7 +16,7 @@ class ResponseBodyAndStatusMatchersTest extends Spec with MatchersTestSupport {
 
   "ResponseBodyAndStatusMatchers" should {
 
-    "match successful request with body content" in new ctx {
+    "match successful response with body content" in new ctx {
       aSuccessfulResponseWith(content) must beSuccessfulWith(content)
       aSuccessfulResponseWith(content) must not( beSuccessfulWith(anotherContent) )
     }
@@ -26,62 +26,62 @@ class ResponseBodyAndStatusMatchersTest extends Spec with MatchersTestSupport {
         s"Matcher misuse: `beSuccessfulWith` received a matcher to match against, please use `beSuccessfulWithEntityThat` instead."
     }
 
-    "match successful request with body content matcher" in new ctx {
+    "match successful response with body content matcher" in new ctx {
       aSuccessfulResponseWith(content) must beSuccessfulWithBodyThat(must = be_===( content ))
       aSuccessfulResponseWith(content) must not( beSuccessfulWithBodyThat(must = be_===( anotherContent )) )
     }
 
-    "match invalid request with body content" in new ctx {
+    "match invalid response with body content" in new ctx {
       anInvalidResponseWith(content) must beInvalidWith(content)
       anInvalidResponseWith(content) must not( beInvalidWith(anotherContent) )
     }
 
-    "match invalid request with body content matcher" in new ctx {
+    "match invalid response with body content matcher" in new ctx {
       anInvalidResponseWith(content) must beInvalidWithBodyThat(must = be_===( content ))
       anInvalidResponseWith(content) must not( beInvalidWithBodyThat(must = be_===( anotherContent )) )
     }
 
-    "match successful request with binary body content" in new ctx {
+    "match successful response with binary body content" in new ctx {
       aSuccessfulResponseWith(binaryContent) must beSuccessfulWith(binaryContent)
       aSuccessfulResponseWith(binaryContent) must not( beSuccessfulWith(anotherBinaryContent) )
     }
 
-    "match successful request with binary body content matcher" in new ctx {
+    "match successful response with binary body content matcher" in new ctx {
       aSuccessfulResponseWith(binaryContent) must beSuccessfulWithBodyDataThat(must = be_===( binaryContent ))
       aSuccessfulResponseWith(binaryContent) must not( beSuccessfulWithBodyDataThat(must = be_===( anotherBinaryContent )) )
     }
 
-    "match successful request with entity" in new ctx {
+    "match successful response with entity" in new ctx {
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
     }
 
-    "match successful request with entity with custom marshaller" in new ctx {
+    "match successful response with entity with custom marshaller" in new ctx {
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWith( someObject )
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWith( anotherObject ) )
     }
 
-    "match successful request with entity matcher" in new ctx {
+    "match successful response with entity matcher" in new ctx {
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must beSuccessfulWithEntityThat( must = be_===( someObject ) )
       aSuccessfulResponseWith(marshaller.marshall(someObject)) must not( beSuccessfulWithEntityThat( must = be_===( anotherObject ) ) )
     }
 
-    "match successful request with headers" in new ctx {
+    "match successful response with headers" in new ctx {
       aSuccessfulResponseWith(header, anotherHeader) must beSuccessfulWithHeaders(header, anotherHeader)
       aSuccessfulResponseWith(header) must not( beSuccessfulWithHeaders(anotherHeader) )
     }
 
-    "match successful request with header matcher" in new ctx {
+    "match successful response with header matcher" in new ctx {
       aSuccessfulResponseWith(header) must beSuccessfulWithHeaderThat(must = be_===(header._2), withHeaderName = header._1)
       aSuccessfulResponseWith(header) must not( beSuccessfulWithHeaderThat(must = be_===(anotherHeader._2), withHeaderName = header._1) )
     }
 
-    "match successful request with cookies" in new ctx {
+    "match successful response with cookies" in new ctx {
       aSuccessfulResponseWithCookies(cookie, anotherCookie) must beSuccessfulWithCookie(cookie.name)
       aSuccessfulResponseWithCookies(cookie) must not( beSuccessfulWithCookie(anotherCookie.name) )
     }
 
-    "match successful request with cookie matcher" in new ctx {
+    "match successful response with cookie matcher" in new ctx {
       aSuccessfulResponseWithCookies(cookie) must beSuccessfulWithCookieThat(must = cookieWith(cookie.value))
       aSuccessfulResponseWithCookies(cookie) must not( beSuccessfulWithCookieThat(must = cookieWith(anotherCookie.value)) )
     }

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseContentTypeMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseContentTypeMatchersTest.scala
@@ -45,7 +45,7 @@ class ResponseContentTypeMatchersTest extends Spec with MatchersTestSupport {
 
     "failure message in case no content type for body should be handled" in new ctx {
       failureMessageFor(haveContentType(contentType), matchedOn = aResponseWithoutBody) must_===
-        "Request body does not have a set content type"
+        "Response body does not have a set content type"
     }
 
     "failure message if someone tries to match content-type in headers matchers" in new ctx {

--- a/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseHeadersMatchersTest.scala
+++ b/http-testkit-specs2/src/test/scala/com/wix/e2e/http/matchers/internal/ResponseHeadersMatchersTest.scala
@@ -40,7 +40,7 @@ class ResponseHeadersMatchersTest extends Spec with MatchersTestSupport {
 
     "haveTheSameHeadersAs matcher will return a message stating what was found, and what is missing from header list" in new ctx {
       failureMessageFor(haveTheSameHeadersAs(header, anotherHeader), matchedOn = aResponseWithHeaders(yetAnotherHeader, header)) must_===
-        s"Request header is not identical, missing headers from request: [${anotherHeader._1}], request contained extra headers: [${yetAnotherHeader._1}]."
+        s"Response header is not identical, missing headers from response: [${anotherHeader._1}], response contained extra headers: [${yetAnotherHeader._1}]."
     }
 
     "header name compare should be case insensitive" in new ctx {
@@ -54,7 +54,7 @@ class ResponseHeadersMatchersTest extends Spec with MatchersTestSupport {
       aResponseWithHeaders(header) must not( haveTheSameHeadersAs(header.copy(_2 = header._2.toUpperCase)) )
     }
     
-    "request with no headers will show a 'no headers' message" in new ctx {
+    "response with no headers will show a 'no headers' message" in new ctx {
       failureMessageFor(haveAnyHeadersOf(header), matchedOn = aResponseWithNoHeaders ) must_===
         "Response did not contain any headers."
 


### PR DESCRIPTION
The response matcher error message suggested that the error in the request while it's matching on the response.