### PR TITLE
Replace stack trace in exceptions thrown by akka-http

### DIFF
--- a/http-testkit-client/src/test/scala/com/wix/e2e/http/client/internals/BUILD.bazel
+++ b/http-testkit-client/src/test/scala/com/wix/e2e/http/client/internals/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+sources()
+
+specs2_unit_test(
+    name = "internals",
+    srcs = [
+        ":sources",
+    ],
+)

--- a/http-testkit-client/src/test/scala/com/wix/e2e/http/client/internals/BlockingRequestManagerTest.scala
+++ b/http-testkit-client/src/test/scala/com/wix/e2e/http/client/internals/BlockingRequestManagerTest.scala
@@ -1,0 +1,38 @@
+package com.wix.e2e.http.client.internals
+
+import org.specs2.mutable.Specification
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.concurrent.{Await, Future}
+
+class BlockingRequestManagerTest extends Specification {
+  "transformException" should {
+    "replace stack" in {
+      val exception = anExceptionWithWrongStack(new RuntimeException)
+      val localStack = Thread.currentThread().getStackTrace.toSeq.drop(2)
+      val throwable = BlockingRequestManager.transformException(exception)
+      throwable.getStackTrace.toSeq.mkString("\n") must endingWith(localStack.mkString("\n"))
+    }
+    "attach suppressed OriginalExceptionStack, if exception with stack " in {
+      val exception = anExceptionWithWrongStack(new RuntimeException)
+      val originalStackTrace = exception.getStackTrace
+      val throwable = BlockingRequestManager.transformException(exception)
+      throwable.getSuppressed.toSeq must contain(like[Throwable] {
+        case e => e.getStackTrace.toSeq must_=== originalStackTrace.toSeq
+      })
+    }
+    "not attach suppressed OriginalExceptionStack, if exception with NO stack " in {
+      val exception = anExceptionWithWrongStack(new RuntimeException)
+      exception.setStackTrace(Array.empty)
+      val throwable = BlockingRequestManager.transformException(exception)
+      throwable.getSuppressed must beEmpty
+    }
+  }
+
+  private def anExceptionWithWrongStack(create: => Throwable): Throwable = {
+    Await.result(Future { create }, 100.millis)
+  }
+
+
+}


### PR DESCRIPTION
Attach the original stack under suppressed exceptions, in case it is of interest